### PR TITLE
Fix Turborepo configuration for deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "my-monorepo",
   "private": true,
+  "packageManager": "npm@9.8.1",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
-    "pipeline": {
+    "$schema": "https://turbo.build/schema.json",
+    "tasks": {
         "build": {
             "dependsOn": [
                 "^build"


### PR DESCRIPTION
## Summary
- specify npm package manager to allow Turbo to resolve workspaces
- migrate `turbo.json` from deprecated `pipeline` to new `tasks` format

## Testing
- `MICROCMS_SERVICE_DOMAIN=dummy MICROCMS_API_KEY=dummy BASE_URL=http://localhost npx turbo run build --filter=kekkonbu` *(fails: Type error: Type 'Props' does not satisfy the constraint 'PageProps')*


------
https://chatgpt.com/codex/tasks/task_e_68997f53c9d0833099998c2c1d372da9