### PR TITLE
Wrap SearchField with Suspense

### DIFF
--- a/apps/kekkonbu/components/Nav/index.tsx
+++ b/apps/kekkonbu/components/Nav/index.tsx
@@ -1,6 +1,7 @@
 import { Category } from '@/libs/microcms';
 import CategoryList from '@/components/CategoryList';
 import SearchField from '@/components/SearchField';
+import { Suspense } from 'react';
 import styles from './index.module.css';
 
 type Props = {
@@ -10,7 +11,9 @@ type Props = {
 export default function Nav({ categories }: Props) {
   return (
     <nav className={styles.nav}>
-      <SearchField />
+      <Suspense fallback={null}>
+        <SearchField />
+      </Suspense>
       <div className={styles.categories}>
         {categories.map((category) => (
           <CategoryList key={category.id} category={category} />


### PR DESCRIPTION
## Summary
- wrap SearchField with a `<Suspense>` boundary so useSearchParams is safe during prerender

## Testing
- `npm test` *(fails: Missing script: "test")*
- `MICROCMS_SERVICE_DOMAIN=dummy MICROCMS_API_KEY=dummy npm run build --workspace=kekkonbu` *(fails: Network Error fetching category list)*

------
https://chatgpt.com/codex/tasks/task_e_6899965626c08330bea050cfbab496ca