### PR TITLE
Load Google AdSense in kekkonbu layout

### DIFF
--- a/apps/kekkonbu/app/layout.tsx
+++ b/apps/kekkonbu/app/layout.tsx
@@ -28,6 +28,13 @@ export default async function RootLayout({ children }: Props) {
   const categories = await getCategoryList();
   return (
     <html lang="ja">
+      <head>
+        <script
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3598027223624482"
+          crossOrigin="anonymous"
+        ></script>
+      </head>
       <body>
         <Header />
         <Nav categories={categories.contents} />


### PR DESCRIPTION
## Summary
- load Google AdSense script in `kekkonbu` layout
- remove AdSense snippet from `sakeflow-site` layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6899af3d8c48833087810c49b80ba4da