### PR TITLE
feat: add title above search bar

### DIFF
--- a/apps/kekkonbu/components/Nav/index.module.css
+++ b/apps/kekkonbu/components/Nav/index.module.css
@@ -8,6 +8,12 @@
   border-bottom: 1px solid var(--color-border-light);
 }
 
+.title {
+  font-size: 32px;
+  font-weight: bold;
+  margin: 0;
+}
+
 .categories {
   display: flex; /* 横並びにする */
   flex-wrap: wrap; /* 必要に応じて折り返し */

--- a/apps/kekkonbu/components/Nav/index.tsx
+++ b/apps/kekkonbu/components/Nav/index.tsx
@@ -11,6 +11,7 @@ type Props = {
 export default function Nav({ categories }: Props) {
   return (
     <nav className={styles.nav}>
+      <h1 className={styles.title}>結婚部</h1>
       <Suspense fallback={null}>
         <SearchField />
       </Suspense>


### PR DESCRIPTION
## Summary
- add “結婚部” heading above search bar on kekkonbu blog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: command sh -c next lint)*

------
https://chatgpt.com/codex/tasks/task_e_6899acf8679883308e958a01b117e49a