### PR TITLE
fix: correct category filtering for sakeflow

### DIFF
--- a/apps/sakeflow-site/app/categories/[categoryId]/p/[current]/page.tsx
+++ b/apps/sakeflow-site/app/categories/[categoryId]/p/[current]/page.tsx
@@ -5,7 +5,7 @@ import ArticleList from '@/components/ArticleList';
 
 type Props = {
   params: {
-    tagId: string;
+    categoryId: string;
     current: string;
   };
 };
@@ -13,17 +13,18 @@ type Props = {
 export const revalidate = 60;
 
 export default async function Page({ params }: Props) {
-  const { tagId } = params;
-  const current = parseInt(params.current as string, 10);
+  const { categoryId } = params;
+  const current = parseInt(params.current, 10);
   const data = await getList({
     limit: LIMIT,
     offset: LIMIT * (current - 1),
-    filters: `tags[contains]${tagId}`,
+    filters: `category[equals]${categoryId}`,
   });
   return (
     <>
       <ArticleList articles={data.contents} />
-      <Pagination totalCount={data.totalCount} current={current} basePath={`/tags/${tagId}`} />
+      <Pagination totalCount={data.totalCount} current={current} basePath={`/categories/${categoryId}`} />
     </>
   );
 }
+

--- a/apps/sakeflow-site/app/categories/[categoryId]/page.tsx
+++ b/apps/sakeflow-site/app/categories/[categoryId]/page.tsx
@@ -5,14 +5,12 @@ import Pagination from '@/components/Pagination';
 import ArticleList from '@/components/ArticleList';
 
 type Props = {
-  params: Promise<{
+  params: {
     categoryId: string;
-    name: string;
-  }>;
+  };
 };
 
-export async function generateMetadata(props: Props): Promise<Metadata> {
-  const params = await props.params;
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { categoryId } = params;
   const category = await getCategory(categoryId);
   return {
@@ -21,19 +19,17 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
       title: category.name,
     },
     alternates: {
-      canonical: `/categories/${params.categoryId}`,
+      canonical: `/categories/${categoryId}`,
     },
   };
 }
 
-export default async function Page(props: Props) {
-  const params = await props.params;
+export default async function Page({ params }: Props) {
   const { categoryId } = params;
   const data = await getList({
     limit: LIMIT,
-    filters: `categories[contains]${categoryId}`,
+    filters: `category[equals]${categoryId}`,
   });
-  const category = await getCategory(categoryId);
   return (
     <>
       <ArticleList articles={data.contents} />
@@ -41,3 +37,4 @@ export default async function Page(props: Props) {
     </>
   );
 }
+


### PR DESCRIPTION
## Summary
- fix category page filter to use `category[equals]`
- correct category pagination paths and params

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899ba2a6fd88330b00e7328d41249d6