### PR TITLE
fix cheerio import and Next.js 15 params

### DIFF
--- a/apps/kekkonbu/app/articles/[slug]/page.tsx
+++ b/apps/kekkonbu/app/articles/[slug]/page.tsx
@@ -4,15 +4,17 @@ import Article from '@/components/Article';
 
 // Next.js 15の型定義に合わせる
 type ArticlePageProps = {
-  params: { slug: string };
-  searchParams: Record<string, string | string[] | undefined>;
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export const revalidate = 60;
 
 export async function generateMetadata({ params, searchParams }: ArticlePageProps): Promise<Metadata> {
-  const draftKey = typeof searchParams.dk === 'string' ? searchParams.dk : undefined;
-  const data = await getDetail(params.slug, {
+  const { slug } = await params;
+  const search = await searchParams;
+  const draftKey = typeof search.dk === 'string' ? search.dk : undefined;
+  const data = await getDetail(slug, {
     draftKey,
   });
 
@@ -28,8 +30,10 @@ export async function generateMetadata({ params, searchParams }: ArticlePageProp
 }
 
 export default async function Page({ params, searchParams }: ArticlePageProps) {
-  const draftKey = typeof searchParams.dk === 'string' ? searchParams.dk : undefined;
-  const data = await getDetail(params.slug, {
+  const { slug } = await params;
+  const search = await searchParams;
+  const draftKey = typeof search.dk === 'string' ? search.dk : undefined;
+  const data = await getDetail(slug, {
     draftKey,
   });
 

--- a/apps/sakeflow-site/app/articles/[slug]/page.tsx
+++ b/apps/sakeflow-site/app/articles/[slug]/page.tsx
@@ -3,19 +3,21 @@ import { getDetail } from '@/libs/microcms';
 import Article from '@/components/Article';
 
 type Props = {
-  params: {
+  params: Promise<{
     slug: string;
-  };
-  searchParams: {
+  }>;
+  searchParams: Promise<{
     dk: string;
-  };
+  }>;
 };
 
 export const revalidate = 60;
 
 export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
-  const data = await getDetail(params.slug, {
-    draftKey: searchParams.dk,
+  const { slug } = await params;
+  const { dk } = await searchParams;
+  const data = await getDetail(slug, {
+    draftKey: dk,
   });
 
   return {
@@ -30,8 +32,10 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
 }
 
 export default async function Page({ params, searchParams }: Props) {
-  const data = await getDetail(params.slug, {
-    draftKey: searchParams.dk,
+  const { slug } = await params;
+  const { dk } = await searchParams;
+  const data = await getDetail(slug, {
+    draftKey: dk,
   });
 
   return <Article data={data} />;

--- a/apps/sakeflow-site/app/categories/[categoryId]/layout.tsx
+++ b/apps/sakeflow-site/app/categories/[categoryId]/layout.tsx
@@ -3,13 +3,13 @@ import styles from './layout.module.css';
 
 type Props = {
   children: React.ReactNode;
-  params: {
+  params: Promise<{
     categoryId: string;
-  };
+  }>;
 };
 
 export default async function CategoryLayout({ children, params }: Props) {
-  const { categoryId } = params;
+  const { categoryId } = await params;
   const category = await getCategory(categoryId);
   return (
     <div>

--- a/apps/sakeflow-site/app/categories/[categoryId]/p/[current]/page.tsx
+++ b/apps/sakeflow-site/app/categories/[categoryId]/p/[current]/page.tsx
@@ -4,26 +4,26 @@ import Pagination from '@/components/Pagination';
 import ArticleList from '@/components/ArticleList';
 
 type Props = {
-  params: {
+  params: Promise<{
     categoryId: string;
     current: string;
-  };
+  }>;
 };
 
 export const revalidate = 60;
 
 export default async function Page({ params }: Props) {
-  const { categoryId } = params;
-  const current = parseInt(params.current, 10);
+  const { categoryId, current } = await params;
+  const currentPage = parseInt(current, 10);
   const data = await getList({
     limit: LIMIT,
-    offset: LIMIT * (current - 1),
+    offset: LIMIT * (currentPage - 1),
     filters: `category[equals]${categoryId}`,
   });
   return (
     <>
       <ArticleList articles={data.contents} />
-      <Pagination totalCount={data.totalCount} current={current} basePath={`/categories/${categoryId}`} />
+      <Pagination totalCount={data.totalCount} current={currentPage} basePath={`/categories/${categoryId}`} />
     </>
   );
 }

--- a/apps/sakeflow-site/app/categories/[categoryId]/page.tsx
+++ b/apps/sakeflow-site/app/categories/[categoryId]/page.tsx
@@ -5,13 +5,13 @@ import Pagination from '@/components/Pagination';
 import ArticleList from '@/components/ArticleList';
 
 type Props = {
-  params: {
+  params: Promise<{
     categoryId: string;
-  };
+  }>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { categoryId } = params;
+  const { categoryId } = await params;
   const category = await getCategory(categoryId);
   return {
     title: category.name,
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default async function Page({ params }: Props) {
-  const { categoryId } = params;
+  const { categoryId } = await params;
   const data = await getList({
     limit: LIMIT,
     filters: `category[equals]${categoryId}`,

--- a/apps/sakeflow-site/app/p/[current]/page.tsx
+++ b/apps/sakeflow-site/app/p/[current]/page.tsx
@@ -4,23 +4,24 @@ import Pagination from '@/components/Pagination';
 import ArticleList from '@/components/ArticleList';
 
 type Props = {
-  params: {
+  params: Promise<{
     current: string;
-  };
+  }>;
 };
 
 export const revalidate = 60;
 
 export default async function Page({ params }: Props) {
-  const current = parseInt(params.current as string, 10);
+  const { current } = await params;
+  const currentPage = parseInt(current, 10);
   const data = await getList({
     limit: LIMIT,
-    offset: LIMIT * (current - 1),
+    offset: LIMIT * (currentPage - 1),
   });
   return (
     <>
       <ArticleList articles={data.contents} />
-      <Pagination totalCount={data.totalCount} current={current} />
+      <Pagination totalCount={data.totalCount} current={currentPage} />
     </>
   );
 }

--- a/apps/sakeflow-site/app/search/p/[current]/page.tsx
+++ b/apps/sakeflow-site/app/search/p/[current]/page.tsx
@@ -4,31 +4,33 @@ import Pagination from '@/components/Pagination';
 import ArticleList from '@/components/ArticleList';
 
 type Props = {
-  params: {
+  params: Promise<{
     current: string;
-  };
-  searchParams: {
+  }>;
+  searchParams: Promise<{
     q?: string;
-  };
+  }>;
 };
 
 export const revalidate = 60;
 
 export default async function Page({ params, searchParams }: Props) {
-  const current = parseInt(params.current as string, 10);
+  const { current } = await params;
+  const { q } = await searchParams;
+  const currentPage = parseInt(current, 10);
   const data = await getList({
     limit: LIMIT,
-    offset: LIMIT * (current - 1),
-    q: searchParams.q,
+    offset: LIMIT * (currentPage - 1),
+    q,
   });
   return (
     <>
       <ArticleList articles={data.contents} />
       <Pagination
         totalCount={data.totalCount}
-        current={current}
+        current={currentPage}
         basePath="/search"
-        q={searchParams.q}
+        q={q}
       />
     </>
   );

--- a/apps/sakeflow-site/app/search/page.tsx
+++ b/apps/sakeflow-site/app/search/page.tsx
@@ -3,22 +3,23 @@ import ArticleList from '@/components/ArticleList';
 import Pagination from '@/components/Pagination';
 
 type Props = {
-  searchParams: {
+  searchParams: Promise<{
     q?: string;
-  };
+  }>;
 };
 
 export const revalidate = 60;
 
 export default async function Page({ searchParams }: Props) {
+  const { q } = await searchParams;
   const data = await getList({
-    q: searchParams.q,
+    q,
   });
 
   return (
     <>
       <ArticleList articles={data.contents} />
-      <Pagination totalCount={data.totalCount} basePath="/search" q={searchParams.q} />
+      <Pagination totalCount={data.totalCount} basePath="/search" q={q} />
     </>
   );
 }

--- a/apps/sakeflow-site/libs/utils.ts
+++ b/apps/sakeflow-site/libs/utils.ts
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
-import cheerio from 'cheerio';
+import * as cheerio from 'cheerio';
 import hljs from 'highlight.js';
 import 'highlight.js/styles/hybrid.css';
 


### PR DESCRIPTION
## Summary
- fix cheerio import for ESM
- update Next.js dynamic pages to use Promise-based params/searchParams

## Testing
- `cd apps/sakeflow-site && npm run build` *(fails: MICROCMS_SERVICE_DOMAIN is required)*
- `cd apps/kekkonbu && npm run build` *(fails: parameter is required (check serviceDomain and apiKey))*

------
https://chatgpt.com/codex/tasks/task_e_689a04e3888c8330bd2b775ad89b3e5a