### PR TITLE
feat: move intro to about page

### DIFF
--- a/apps/kekkonbu/app/about/page.tsx
+++ b/apps/kekkonbu/app/about/page.tsx
@@ -1,0 +1,9 @@
+import Intro from '@/components/Intro';
+
+export const metadata = {
+  title: 'このブログについて',
+};
+
+export default function AboutPage() {
+  return <Intro />;
+}

--- a/apps/kekkonbu/app/page.tsx
+++ b/apps/kekkonbu/app/page.tsx
@@ -2,7 +2,6 @@ import { getList } from '@/libs/microcms';
 import { LIMIT } from '@/constants';
 import Pagination from '@/components/Pagination';
 import ArticleList from '@/components/ArticleList';
-import Intro from '@/components/Intro';
 
 export const revalidate = 60;
 
@@ -12,7 +11,6 @@ export default async function Page() {
   });
   return (
     <>
-      <Intro />
       <ArticleList articles={data.contents} />
       <Pagination totalCount={data.totalCount} />
     </>

--- a/apps/kekkonbu/components/Nav/index.module.css
+++ b/apps/kekkonbu/components/Nav/index.module.css
@@ -14,6 +14,18 @@
   margin: 0;
 }
 
+.menu {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+}
+
+.menuItem {
+  text-decoration: none;
+  color: inherit;
+  font-size: 14px;
+}
+
 .categories {
   display: flex; /* 横並びにする */
   flex-wrap: wrap; /* 必要に応じて折り返し */

--- a/apps/kekkonbu/components/Nav/index.tsx
+++ b/apps/kekkonbu/components/Nav/index.tsx
@@ -1,6 +1,7 @@
 import { Category } from '@/libs/microcms';
 import CategoryList from '@/components/CategoryList';
 import SearchField from '@/components/SearchField';
+import Link from 'next/link';
 import { Suspense } from 'react';
 import styles from './index.module.css';
 
@@ -12,6 +13,11 @@ export default function Nav({ categories }: Props) {
   return (
     <nav className={styles.nav}>
       <h1 className={styles.title}>結婚部</h1>
+      <div className={styles.menu}>
+        <Link href="/about" className={styles.menuItem}>
+          このブログについて
+        </Link>
+      </div>
       <Suspense fallback={null}>
         <SearchField />
       </Suspense>


### PR DESCRIPTION
## Summary
- add top navigation menu with link to about page
- move blog introduction to dedicated about page
- remove intro from homepage

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689c4c3ef0fc83309da64349bd851bbe